### PR TITLE
[WIP] Component API

### DIFF
--- a/example/Admin.re
+++ b/example/Admin.re
@@ -1,5 +1,3 @@
-open Navigation;
-
 open BsReactNative;
 
 let component = ReasonReact.statelessComponent("Admin");
@@ -9,26 +7,21 @@ module Styles = {
     Style.(style([flex(1.), justifyContent(Center), alignItems(Center)]));
 };
 
-let renderButtons = (nav: StackNavigator.navigation) =>
+let renderButtons = (~push, ~pop) =>
   <View>
-    <TouchableOpacity onPress=(_e => nav.push(Config.Home))>
+    <TouchableOpacity onPress=(_e => push())>
       <Text> (ReasonReact.stringToElement("Push")) </Text>
     </TouchableOpacity>
-    <TouchableOpacity onPress=(_e => nav.pop())>
+    <TouchableOpacity onPress=(_e => pop())>
       <Text> (ReasonReact.stringToElement("Pop")) </Text>
     </TouchableOpacity>
   </View>;
 
-let make = (~navigation, _children) => {
+let make = (~push, ~pop, _children) => {
   ...component,
   render: _self =>
-    <StackNavigator.Screen headerTitle="Admin" navigation>
-      ...(
-           () =>
-             <View>
-               <Text> (ReasonReact.stringToElement("Admin")) </Text>
-               (renderButtons(navigation))
-             </View>
-         )
-    </StackNavigator.Screen>
+    <View>
+      <Text> (ReasonReact.stringToElement("Admin")) </Text>
+      (renderButtons(~push, ~pop))
+    </View>
 };

--- a/example/App.re
+++ b/example/App.re
@@ -1,19 +1,42 @@
-open Navigation;
+module Screens = {
+  let homeScreen = StackNavigator.makeScreen();
+  let adminScreen = StackNavigator.makeScreen();
+  let makeHomeScreen = () => {
+    ...homeScreen,
+    initialState: () => false,
+    render: (_, send) => <Home push=(() => send(true)) pop=(() => ()) />,
+    reducer: (_, x) => x,
+    key: "Home",
+    popChild: (_) => false,
+    renderChild: (state, _) =>
+      if (state) {
+        Some(Screen(makeAdminScreen()));
+      } else {
+        None;
+      }
+  }
+  and makeAdminScreen = () => {
+    ...adminScreen,
+    initialState: () => false,
+    render: (_, send) => <Admin push=(() => send(true)) pop=(() => ()) />,
+    reducer: (_, x) => x,
+    key: "Home",
+    popChild: (_) => false,
+    renderChild: (state, _) =>
+      if (state) {
+        Some(Screen(makeHomeScreen()));
+      } else {
+        None;
+      }
+  };
+};
 
 module Main = {
   let component = ReasonReact.statelessComponent("App");
   let make = _children => {
     ...component,
     render: _self =>
-      <StackNavigator initialRoute=Config.Admin>
-        ...(
-             (~currentRoute, ~navigation) =>
-               switch currentRoute {
-               | Config.Admin => <Admin navigation />
-               | Config.Home => <Home navigation />
-               }
-           )
-      </StackNavigator>
+      <StackNavigator initialScreen=(Screens.makeHomeScreen()) />
   };
 };
 

--- a/example/Home.re
+++ b/example/Home.re
@@ -1,26 +1,22 @@
-open Navigation;
-
 open BsReactNative;
 
 let component = ReasonReact.statelessComponent("Home");
 
-let make = (~navigation as nav: StackNavigator.navigation, _children) => {
+let make = (~push, ~pop, _children) => {
   ...component,
   render: _self =>
-    <StackNavigator.Screen headerTitle="Home" navigation=nav>
-      ...(
-           () =>
-             <View>
-               <Text> (ReasonReact.stringToElement("Home")) </Text>
-               <View>
-                 <TouchableOpacity onPress=(_e => nav.push(Config.Admin))>
-                   <Text> (ReasonReact.stringToElement("Push")) </Text>
-                 </TouchableOpacity>
-                 <TouchableOpacity onPress=(_e => nav.pop())>
-                   <Text> (ReasonReact.stringToElement("Pop")) </Text>
-                 </TouchableOpacity>
-               </View>
-             </View>
-         )
-    </StackNavigator.Screen>
+    <View>
+      <View>
+        <Text> (ReasonReact.stringToElement("Home")) </Text>
+        <View>
+          <TouchableOpacity onPress=(_e => push())>
+            <Text> (ReasonReact.stringToElement("Push")) </Text>
+          </TouchableOpacity>
+          <TouchableOpacity onPress=(_e => pop())>
+            <Text> (ReasonReact.stringToElement("Pop")) </Text>
+          </TouchableOpacity>
+        </View>
+      </View>
+    </View>
 };
+

--- a/example/Navigation.re
+++ b/example/Navigation.re
@@ -1,7 +1,0 @@
-module Config = {
-  type route =
-    | Admin
-    | Home;
-};
-
-include ReRoute.CreateNavigation(Config);

--- a/src/ReRoute.re
+++ b/src/ReRoute.re
@@ -1,3 +1,0 @@
-module CreateNavigation = (Config: {type route;}) => {
-  include StackNavigator.CreateStackNavigator(Config);
-};

--- a/src/StackNavigator.re
+++ b/src/StackNavigator.re
@@ -2,6 +2,142 @@ open BsReactNative;
 
 open Utils;
 
+type screenSpec('state, 'action) = {
+  initialState: unit => 'state,
+  key: string,
+  reducer: ('state, 'action) => 'state,
+  render: ('state, 'action => unit) => ReasonReact.reactElement,
+  renderChild: ('state, 'action => unit) => option(opaqueScreen),
+  popChild: 'state => 'state,
+  handedOffState: handedOffState('state, 'action)
+}
+and opaqueScreen =
+  | Screen(screenSpec('state, 'action)): opaqueScreen
+and handedOffState('state, 'action) = ref(option(screenSpec('state, 'action)));
+
+type instance('state, 'action) = {
+  screen: screenSpec('state, 'action),
+  instanceState: 'state,
+  child: option(opaqueInstance),
+  header: Header.config,
+  animatedValue: Animated.Value.t,
+  animation: Animation.t
+}
+and opaqueInstance =
+  | Instance(instance('state, 'action)): opaqueInstance;
+
+let rec updateInstance =
+        (
+          Instance(
+            {screen, instanceState: currentState, child: oldChild} as currentInstance
+          ),
+          send
+        ) =>
+  Instance(
+    {
+      let thisState = currentState;
+      {
+        ...currentInstance,
+        screen,
+        instanceState: thisState,
+        child: {
+          let newChild =
+            screen.renderChild(
+              thisState,
+              action => {
+                let nextState = screen.reducer(thisState, action);
+                send(
+                  Instance({
+                    ...currentInstance,
+                    screen,
+                    instanceState: nextState,
+                    child: oldChild
+                  })
+                );
+              }
+            );
+          switch (oldChild, newChild) {
+          | (Some(_), None)
+          | (None, None) => None
+          | (
+              Some(
+                Instance(
+                  {screen: oldScreen, instanceState: oldState, child: oldChild} as oldChildImpl
+                )
+              ),
+              Some(Screen(childScreen))
+            ) =>
+            childScreen.handedOffState := Some(childScreen);
+            switch oldScreen.handedOffState^ {
+            | Some(newChildScreen) =>
+              childScreen.handedOffState := None;
+              Some(
+                updateInstance(
+                  Instance({
+                    ...oldChildImpl,
+                    screen: newChildScreen,
+                    instanceState: oldState,
+                    child: oldChild
+                  }),
+                  childUpdate =>
+                  send(
+                    Instance({
+                      ...oldChildImpl,
+                      screen: newChildScreen,
+                      instanceState: oldState,
+                      child: Some(childUpdate)
+                    })
+                  )
+                )
+              );
+            | None =>
+              childScreen.handedOffState := None;
+              Some(renderNewChild(childScreen, send, screen, thisState));
+            };
+          | (None, Some(Screen(childScreen))) =>
+            Some(renderNewChild(childScreen, send, screen, thisState))
+          };
+        }
+      };
+    }
+  )
+and renderNewChild:
+  'childState 'childAction 'state 'action .
+  (
+    screenSpec('childState, 'childAction),
+    opaqueInstance => unit,
+    screenSpec('state, 'action),
+    'state
+  ) =>
+  opaqueInstance
+ =
+  (childScreen, send, screen, thisState) => {
+    let header = Header.default;
+    let animation = Animation.default;
+    let animatedValue = Animated.Value.create(1.0);
+    updateInstance(
+      Instance({
+        screen: childScreen,
+        instanceState: childScreen.initialState(),
+        child: None,
+        header,
+        animation,
+        animatedValue
+      }),
+      childUpdate =>
+      send(
+        Instance({
+          screen,
+          instanceState: thisState,
+          child: Some(childUpdate),
+          header,
+          animation,
+          animatedValue
+        })
+      )
+    );
+  };
+
 module Styles = {
   open Style;
   let fill =
@@ -24,430 +160,368 @@ module Styles = {
   let stackContainer = concat([flex, style([flexDirection(ColumnReverse)])]);
 };
 
-module CreateStackNavigator = (Config: {type route;}) => {
-  module StackNavigator = {
-    type screenConfig = {
-      route: Config.route,
-      key: string,
-      header: Header.config,
-      animatedValue: Animated.Value.t,
-      animation: Animation.t,
-      style: Style.t
-    };
-    type state = {
-      screens: array(screenConfig),
-      activeScreen: int
-    };
-    type options = {
-      header: Header.config,
-      animation: option(Animation.t),
-      style: option(Style.t)
-    };
-    type action =
-      | PushScreen(Config.route, string)
-      | SetOptions(options, string)
-      | RemoveStaleScreen(string)
-      | RemoveLastScreen
-      | PopScreen(string);
-    type navigation = {
-      push: Config.route => unit,
-      setOptions: options => unit,
-      pop: unit => unit
-    };
-    let headerAnimatedValue = Animated.Value.create(0.0);
-    /**
-     * Gestures
-     */
-    module Gestures = {
-      /** PanGestureHandler from `react-native-gesture-handler */
-      module PanHandler = {
-        [@bs.module "react-native-gesture-handler"]
-        external view : ReasonReact.reactClass = "PanGestureHandler";
-        let make =
-            (
-              ~onGestureEvent,
-              ~maxDeltaX,
-              ~enabled,
-              ~onHandlerStateChange,
-              ~minDeltaX,
-              ~hitSlop,
-              children
-            ) =>
-          ReasonReact.wrapJsForReason(
-            ~reactClass=view,
-            ~props={
-              "onGestureEvent": onGestureEvent,
-              "onHandlerStateChange": onHandlerStateChange,
-              "maxDeltaX": maxDeltaX,
-              "minDeltaX": minDeltaX,
-              "enabled": Js.Boolean.to_js_boolean(enabled),
-              "hitSlop": hitSlop
-            },
-            children
-          );
-      };
-      let screenWidth = Dimensions.get(`window)##width;
-      /** Raw value as updated via `handler` from PanGestureHandler */
-      let animatedValue = Animated.Value.create(0.0);
-      let handler =
-        Animated.event(
-          [|{
-              "nativeEvent": {
-                "translationX": animatedValue
-              }
-            }|],
-          {"useNativeDriver": true}
-        );
-      /** Interpolated progress in range of 0 to 1 (start to end) */
-      let animatedProgress =
-        AnimatedUtils.interpolate(
-          animatedValue,
-          ~inputRange=[0.0, float_of_int(screenWidth)],
-          ~outputRange=`float([0.0, 1.0]),
-          ~extrapolate=Animated.Interpolation.Clamp,
-          ()
-        );
-      /**
+let headerAnimatedValue = Animated.Value.create(0.0);
+
+/**
+ * Gestures
+ */
+module Gestures = {
+  /** PanGestureHandler from `react-native-gesture-handler */
+  module PanHandler = {
+    [@bs.module "react-native-gesture-handler"]
+    external view : ReasonReact.reactClass = "PanGestureHandler";
+    let make =
+        (
+          ~onGestureEvent,
+          ~maxDeltaX,
+          ~enabled,
+          ~onHandlerStateChange,
+          ~minDeltaX,
+          ~hitSlop,
+          children
+        ) =>
+      ReasonReact.wrapJsForReason(
+        ~reactClass=view,
+        ~props={
+          "onGestureEvent": onGestureEvent,
+          "onHandlerStateChange": onHandlerStateChange,
+          "maxDeltaX": maxDeltaX,
+          "minDeltaX": minDeltaX,
+          "enabled": Js.Boolean.to_js_boolean(enabled),
+          "hitSlop": hitSlop
+        },
+        children
+      );
+  };
+  let screenWidth = Dimensions.get(`window)##width;
+  /** Raw value as updated via `handler` from PanGestureHandler */
+  let animatedValue = Animated.Value.create(0.0);
+  let handler =
+    Animated.event(
+      [|{
+          "nativeEvent": {
+            "translationX": animatedValue
+          }
+        }|],
+      {"useNativeDriver": true}
+    );
+  /** Interpolated progress in range of 0 to 1 (start to end) */
+  let animatedProgress =
+    AnimatedUtils.interpolate(
+      animatedValue,
+      ~inputRange=[0.0, float_of_int(screenWidth)],
+      ~outputRange=`float([0.0, 1.0]),
+      ~extrapolate=Animated.Interpolation.Clamp,
+      ()
+    );
+  /** Interpolated progress in range of 0 to 1 (start to end) */
+  let animatedProgress =
+    AnimatedUtils.interpolate(
+      animatedValue,
+      ~inputRange=[0.0, float_of_int(screenWidth)],
+      ~outputRange=`float([0.0, 1.0]),
+      ~extrapolate=Animated.Interpolation.Clamp,
+      ()
+    );
+  /**
        * Called when gesture state changes (5 - end)
        *
        * At the end of the animation, make sure to reset gesture
        * state to `0` and update all the other animated values
        * accordingly.
        */
-      let onStateChange = (event, self) => {
-        let e = event##nativeEvent;
-        switch e##state {
-        | 5 =>
-          let toValue =
-            e##translationX > screenWidth / 2 || e##velocityX > 150.00 ?
-              screenWidth : 0;
-          Animated.CompositeAnimation.start(
-            Animated.Spring.animate(
-              ~value=animatedValue,
-              ~velocity=e##velocityX,
-              ~useNativeDriver=Js.true_,
-              ~toValue=`raw(float_of_int(toValue)),
-              ()
-            ),
-            ~callback=
-              _end_ =>
-                if (toValue != 0) {
-                  let {screens, activeScreen} = self.ReasonReact.state;
-                  Animated.Value.setValue(
-                    screens[activeScreen - 1].animatedValue,
-                    0.0
-                  );
-                  Animated.Value.setValue(
-                    screens[activeScreen].animatedValue,
-                    1.0
-                  );
-                  Animated.Value.setValue(
-                    headerAnimatedValue,
-                    float_of_int(activeScreen - 1)
-                  );
-                  Animated.Value.setValue(animatedValue, 0.0);
-                  self.ReasonReact.send(RemoveLastScreen);
-                },
-            ()
-          );
-        | _ => ()
-        };
-      };
+  let onStateChange =
+      (
+        event,
+        activeScreen,
+        previousScreen,
+        activeScreenIndex,
+        commitViewChange
+      ) => {
+    let e = event##nativeEvent;
+    switch e##state {
+    | 5 =>
+      let toValue =
+        e##translationX > screenWidth / 2 || e##velocityX > 150.00 ?
+          screenWidth : 0;
+      Animated.CompositeAnimation.start(
+        Animated.Spring.animate(
+          ~value=animatedValue,
+          ~velocity=e##velocityX,
+          ~useNativeDriver=Js.true_,
+          ~toValue=`raw(float_of_int(toValue)),
+          ()
+        ),
+        ~callback=
+          _end_ =>
+            if (toValue != 0) {
+              Animated.Value.setValue(previousScreen.animatedValue, 0.0);
+              Animated.Value.setValue(activeScreen.animatedValue, 1.0);
+              Animated.Value.setValue(
+                headerAnimatedValue,
+                float_of_int(activeScreenIndex)
+              );
+              Animated.Value.setValue(animatedValue, 0.0);
+            },
+        commitViewChange()
+      );
+    | _ => ()
     };
-    /**
-     * Helpers specific to this module
-     */
-    module Helpers = {
-      let isActiveScreen = (state, key) =>
-        state.screens[state.activeScreen].key == key;
-    };
-    /**
-     * StackNavigator component
-     */
-    let component = ReasonReact.reducerComponent("StackNavigator");
-    let make = (~initialRoute, children) => {
-      ...component,
-      initialState: () => {
-        screens: [|
-          {
-            route: initialRoute,
-            header: Header.default,
-            animation: Animation.default,
-            key: UUID.generate(),
-            animatedValue: Animated.Value.create(0.0),
-            style: Styles.card
-          }
-        |],
-        activeScreen: 0
-      },
-      /***
-       * Begin animating two states as soon as the index changes.
-       *
-       * No animation is done when screen has been already removed from the array.
-       *
-       * The animation is configured based on the latter screen. That said,
-       * when screen B (being removed) uses `fade` transition, the screen
-       * that is to appear will fade in (even though it doesn't define custom
-       * animation itself).
-       *
-       * Values -1, 0, 1 describe position on screen. Screen with value `0` is the
-       * one that is currently visible. Screen with "1" is rendered and hidden on the
-       * right hand side whereas "-1" is hidden on the left hand side.
-       *
-       * Example:
-       * 0 to -1 -> next screen has been pushed
-       * 0 to 1 -> this screen is getting popped
-       * -1 to 0 -> next screen has been popped
-       * 1 to 0 -> this screen has been pushed
-       */
-      didUpdate: ({oldSelf, newSelf: self}) => {
-        let fromIdx = oldSelf.state.activeScreen;
-        let toIdx = self.state.activeScreen;
-        let needsAnimation =
-          Array.length(self.state.screens) > Js.Math.max_int(toIdx, fromIdx);
-        if (fromIdx !== toIdx && needsAnimation) {
-          let (first, second) =
-            fromIdx < toIdx ?
-              (self.state.screens[fromIdx], self.state.screens[toIdx]) :
-              (self.state.screens[toIdx], self.state.screens[fromIdx]);
-          let action = fromIdx < toIdx ? `Push : `Pop;
-          let (fstValues, sndValues) =
-            switch action {
-            | `Push => ((0.0, (-1.0)), (1.0, 0.0))
-            | `Pop => (((-1.0), 0.0), (0.0, 1.0))
-            };
-          Animated.CompositeAnimation.start(
-            Animated.parallel(
-              [|
-                second.animation.func(
-                  ~value=Gestures.animatedValue,
-                  ~toValue=`raw(0.0)
-                ),
-                second.animation.func(
-                  ~value=headerAnimatedValue,
-                  ~toValue=`raw(float_of_int(toIdx))
-                ),
-                second.animation.func(
-                  ~value=first.animatedValue,
-                  ~toValue=`raw(fstValues |> snd)
-                ),
-                second.animation.func(
-                  ~value=second.animatedValue,
-                  ~toValue=`raw(sndValues |> snd)
-                )
-              |],
-              {"stopTogether": Js.Boolean.to_js_boolean(false)}
-            ),
-            ~callback=
-              end_ =>
-                if (action == `Pop && Js.to_bool(end_##finished)) {
-                  self.send(RemoveStaleScreen(second.key));
-                },
-            ()
-          );
-          ();
-        };
-      },
-      /***
-       * StackNavigator router
-       *
-       * Most actions are indempotent and have `isActiveScreen(state, key)` check
-       * to make sure we only accept one action from the screen that changes the
-       * state.
-       */
-      reducer: (action, state) =>
-        switch action {
-        /***
-         * Pushes new screen onto the stack
-         *
-         * Note: We push the item right after the active one (instead of always
-         * adding to the end). This is to make sure no glitches happen when you
-         * push in the middle of a pop.
-         */
-        | PushScreen(route, key) =>
-          if (Helpers.isActiveScreen(state, key)) {
-            let index = state.activeScreen + 1;
-            ReasonReact.Update({
-              activeScreen: index,
-              screens:
-                state.screens
-                |> ReArray.append(
-                     {
-                       route,
-                       header: Header.default,
-                       animation: Animation.default,
-                       animatedValue: Animated.Value.create(1.0),
-                       key: UUID.generate(),
-                       style: Styles.card
-                     },
-                     index
-                   )
-            });
-          } else {
-            ReasonReact.NoUpdate;
-          }
-        /***
-         * Pops screen from the stack
-         */
-        | PopScreen(key) =>
-          if (state.activeScreen > 0 && Helpers.isActiveScreen(state, key)) {
-            ReasonReact.Update({
-              ...state,
-              activeScreen: state.activeScreen - 1
-            });
-          } else {
-            ReasonReact.NoUpdate;
-          }
-        /***
-         * Removes a stale screen from the stack w/o animation.
-         *
-         * This is usually done when the pop animation of particular screen
-         * finishes and the screen is no longer within the viewport.
-         */
-        | RemoveStaleScreen(key) =>
-          let idx =
-            state.screens
-            |> Js.Array.findIndex((screen: screenConfig) => screen.key == key);
-          ReasonReact.Update({
-            ...state,
-            screens: state.screens |> ReArray.remove(idx)
-          });
-        | RemoveLastScreen =>
-          ReasonReact.Update({
-            activeScreen: state.activeScreen - 1,
-            screens: state.screens |> ReArray.remove(state.activeScreen)
-          })
-        /***
-         * Sets option for a screen with a given key
-         */
-        | SetOptions({header, animation, style}, key) =>
-          let screens = Js.Array.copy(state.screens);
-          let idx =
-            screens
-            |> Js.Array.findIndex((screen: screenConfig) => screen.key == key);
-          screens[idx] = {
-            ...screens[idx],
+  };
+};
+
+let rec renderAll =
+        (
+          Instance({
+            screen,
+            instanceState,
+            child,
             header,
-            style: style |> Js.Option.getWithDefault(screens[idx].style),
-            animation:
-              animation |> Js.Option.getWithDefault(screens[idx].animation)
-          };
-          ReasonReact.Update({...state, screens});
+            animatedValue,
+            animation
+          }),
+          send,
+          depth
+        ) => {
+  let animationStyle =
+    if (depth == 0) {
+      Style.style([]);
+    } else {
+      let screenAnimation =
+        switch child {
+        | Some(Instance({animation: childAnimation})) => childAnimation
+        | None => animation
+        };
+      Animated.Value.add(Gestures.animatedProgress, animatedValue)
+      |> screenAnimation.forCard({idx: depth + 1});
+    };
+  [
+    (
+      {Header.header, animation, key: screen.key},
+      ReasonReact.element(
+        ~key=screen.key,
+        Animated.View.make(
+          ~style=Style.(concat([Styles.fill, animationStyle])),
+          [|
+            ReasonReact.element(
+              View.make([|
+                screen.render(
+                  instanceState,
+                  action => {
+                    let nextState = screen.reducer(instanceState, action);
+                    send(
+                      Instance({
+                        screen,
+                        instanceState: nextState,
+                        child,
+                        header,
+                        animatedValue,
+                        animation
+                      })
+                    );
+                  }
+                )
+              |])
+            )
+          |]
+        )
+      )
+    ),
+    ...switch child {
+       | Some(childInstance) =>
+         renderAll(
+           childInstance,
+           childUpdate =>
+             send(
+               Instance({
+                 screen,
+                 instanceState,
+                 child: Some(childUpdate),
+                 header,
+                 animatedValue,
+                 animation
+               })
+             ),
+           depth + 1
+         )
+       | None => []
+       }
+  ];
+};
+
+type updateAnimation =
+  | Push(opaqueInstance, opaqueInstance, int)
+  | Pop(opaqueInstance, opaqueInstance, int)
+  | Replace;
+
+type state =
+  | Displaying(opaqueInstance)
+  | Animating(updateAnimation, opaqueInstance);
+
+let container = ReasonReact.reducerComponent("Navigator_Container");
+
+let make = (~initialScreen, ()) => {
+  ...container,
+  initialState: () =>
+    updateInstance(
+      Instance({
+        header: Header.default,
+        animation: Animation.default,
+        animatedValue: Animated.Value.create(1.0),
+        screen: initialScreen,
+        instanceState: initialScreen.initialState(),
+        child: None
+      }),
+      (_) =>
+      ()
+    ),
+  reducer: (newInstance, _) => ReasonReact.Update(newInstance),
+  didMount: ({send, state}) => {
+    let rec sender = screenUpdate =>
+      send(updateInstance(screenUpdate, sender));
+    ReasonReact.Update(updateInstance(state, sender));
+  }
+};
+
+let performAnimation =
+    (~first, ~firstToValue, ~secondToValue, ~second, ~secondIndex, ~finished) =>
+  Animated.CompositeAnimation.start(
+    Animated.parallel(
+      [|
+        second.animation.func(
+          ~value=Gestures.animatedValue,
+          ~toValue=`raw(0.0)
+        ),
+        second.animation.func(
+          ~value=headerAnimatedValue,
+          ~toValue=`raw(float_of_int(secondIndex))
+        ),
+        second.animation.func(
+          ~value=first.animatedValue,
+          ~toValue=`raw(firstToValue)
+        ),
+        second.animation.func(
+          ~value=second.animatedValue,
+          ~toValue=`raw(secondToValue)
+        )
+      |],
+      {
+        module J = {
+          external unsafe_expr :
+            (~stopTogether: 'a0) => {. "stopTogether": 'a0} =
+            ""
+            "BS:2.2.2\132\149¦¾\000\000\000\020\000\000\000\005\000\000\000\016\000\000\000\014\145  B ,stopTogether@@";
+        };
+        J.unsafe_expr(~stopTogether=Js.Boolean.to_js_boolean(false));
+      }
+    ),
+    ~callback=
+      end_ =>
+        if (Js.to_bool(end_##finished)) {
+          finished();
         },
-      render: self => {
-        let size = Array.length(self.state.screens);
-        let screenWidth = Dimensions.get(`window)##width;
-        /**
-         * Aquapoint is the distance between parent and its sibling
-         * used by default on iOS (auto-layout constraint). This is
-         * the used for defining how far from the screen your gesture
-         * can start.
-         *
-         * Source: https://goo.gl/FVKnzZ
-         */
-        let aquaPoint = 20;
-        <View style=Styles.stackContainer>
-          <Gestures.PanHandler
-            minDeltaX=aquaPoint
-            hitSlop={"right": aquaPoint - screenWidth}
-            maxDeltaX=screenWidth
-            enabled=(size > 1)
-            onGestureEvent=Gestures.handler
-            onHandlerStateChange=(self.handle(Gestures.onStateChange))>
-            <Animated.View style=Styles.flex>
-              (
-                self.state.screens
-                |> Array.mapi((idx, screen: screenConfig) => {
-                     let animation =
-                       if (size == 1) {
-                         Style.style([]);
-                       } else {
-                         let scr =
-                           idx + 1 == size ?
-                             screen : self.state.screens[idx + 1];
-                         Animated.Value.add(
-                           Gestures.animatedProgress,
-                           screen.animatedValue
-                         )
-                         |> scr.animation.forCard({idx: idx});
-                       };
-                     <Animated.View
-                       key=screen.key
-                       style=Style.(
-                               concat([Styles.fill, screen.style, animation])
-                             )>
-                       <View>
-                         (
-                           children(
-                             ~currentRoute=screen.route,
-                             ~navigation={
-                               push: route =>
-                                 self.send(PushScreen(route, screen.key)),
-                               pop: () => self.send(PopScreen(screen.key)),
-                               setOptions: opts =>
-                                 self.send(SetOptions(opts, screen.key))
-                             }
-                           )
-                         )
-                       </View>
-                     </Animated.View>;
-                   })
-                |> ReasonReact.arrayToElement
+    ()
+  );
+
+let onDidUpdate = (updateType, finished) =>
+  switch updateType {
+  | Replace => ()
+  | Push(Instance(fromInstance), Instance(toInstance), toIndex) =>
+    performAnimation(
+      ~first=fromInstance,
+      ~firstToValue=-1.0,
+      ~second=toInstance,
+      ~secondToValue=0.0,
+      ~secondIndex=toIndex,
+      ~finished
+    )
+  | Pop(Instance(fromInstance), Instance(toInstance), toIndex) =>
+    performAnimation(
+      ~first=fromInstance,
+      ~firstToValue=0.0,
+      ~second=toInstance,
+      ~secondToValue=1.0,
+      ~secondIndex=toIndex,
+      ~finished
+    )
+  };
+
+let renderImplementation = (state, send) => {
+  let rec sender = screenUpdate => send(updateInstance(screenUpdate, sender));
+  let screens =
+    switch state {
+    | Animating(Pop(fromInstance, _, _), instance) =>
+      List.append(
+        renderAll(instance, sender, 0),
+        renderAll(fromInstance, (_) => (), 0)
+      )
+      |> Array.of_list
+    | Displaying(instance)
+    | Animating(_, instance) => renderAll(instance, sender, 0) |> Array.of_list
+    };
+  let screenWidth = Dimensions.get(`window)##width;
+  /**
+ * Aquapoint is the distance between parent and its sibling
+ * used by default on iOS (auto-layout constraint). This is
+ * the used for defining how far from the screen your gesture
+ * can start.
+ *
+ * Source: https://goo.gl/FVKnzZ
+ */
+  let aquaPoint = 20;
+  ReasonReact.element(
+    View.make(
+      ~style=Styles.stackContainer,
+      [|
+        ReasonReact.element(
+          Gestures.PanHandler.make(
+            ~minDeltaX=aquaPoint,
+            ~hitSlop={"right": aquaPoint - screenWidth},
+            ~maxDeltaX=screenWidth,
+            ~enabled=Array.length(screens) > 1,
+            ~onGestureEvent=Gestures.handler,
+            ~onHandlerStateChange=(_) => Gestures.onStateChange,
+            [|
+              ReasonReact.element(
+                Animated.View.make(
+                  ~style=Styles.flex,
+                  [|screens |> Array.map(snd) |> ReasonReact.arrayToElement|]
+                )
               )
-            </Animated.View>
-          </Gestures.PanHandler>
-          <Header.PlatformHeader
-            animatedValue=(
+            |]
+          )
+        ),
+        ReasonReact.element(
+          Header.PlatformHeader.make(
+            ~animatedValue=
               Animated.Value.add(
                 headerAnimatedValue,
                 Animated.Value.multiply(
                   Gestures.animatedProgress,
                   Animated.Value.create(-1.0)
                 )
-              )
-            )
-            pop=(key => self.send(PopScreen(key)))
-            activeScreen=self.state.activeScreen
-            screens=(
-              self.state.screens
-              |> Array.map((scr: screenConfig) =>
-                   {
-                     Header.header: scr.header,
-                     animation: scr.animation,
-                     key: scr.key
-                   }
-                 )
-            )
-          />
-        </View>;
-      }
-    };
-    module Screen = {
-      let component = ReasonReact.statelessComponent("CallstackScreen");
-      let make =
-          (
-            ~navigation: navigation,
-            ~style=?,
-            ~headerTitle=?,
-            ~animation=?,
-            children
-          ) => {
-        ...component,
-        didMount: _self => {
-          navigation.setOptions({
-            header: {
-              title: headerTitle
-            },
-            animation,
-            style
-          });
-          ReasonReact.NoUpdate;
-        },
-        render: _self => {
-          let body = children();
-          <View> body </View>;
-        }
-      };
-    };
-  };
+              ),
+            ~pop=(_) => (),
+            ~activeScreen=Array.length(screens) - 1,
+            ~screens=screens |> Array.map(fst),
+            [||]
+          )
+        )
+      |]
+    )
+  );
+};
+
+type unknownState = unit;
+
+type unknownAction = unit;
+
+let makeScreen = () => {
+  handedOffState: ref(None),
+  initialState: () => (),
+  reducer: (_, _) => (),
+  render: (_, _) => ReasonReact.nullElement,
+  renderChild: (_, _) => None,
+  popChild: () => (),
+  key: ""
 };

--- a/src/StackNavigator.rei
+++ b/src/StackNavigator.rei
@@ -1,44 +1,33 @@
-module CreateStackNavigator:
-  (Config: {type route;}) =>
-  {
-    module StackNavigator: {
-      type state;
-      type options;
-      type action;
-      type navigation = {
-        push: Config.route => unit,
-        setOptions: options => unit,
-        pop: unit => unit
-      };
-      let make:
-        (
-          ~initialRoute: Config.route,
-          (~currentRoute: Config.route, ~navigation: navigation) =>
-          ReasonReact.reactElement
-        ) =>
-        ReasonReact.componentSpec(
-          state,
-          state,
-          ReasonReact.noRetainedProps,
-          ReasonReact.noRetainedProps,
-          action
-        );
-      module Screen: {
-        let make:
-          (
-            ~navigation: navigation,
-            ~style: BsReactNative.Style.t=?,
-            ~headerTitle: string=?,
-            ~animation: Animation.t=?,
-            unit => ReasonReact.reactElement
-          ) =>
-          ReasonReact.componentSpec(
-            ReasonReact.stateless,
-            ReasonReact.stateless,
-            ReasonReact.noRetainedProps,
-            ReasonReact.noRetainedProps,
-            ReasonReact.actionless
-          );
-      };
-    };
-  };
+type handedOffState('state, 'action);
+
+type screenSpec('state, 'action) = {
+  initialState: unit => 'state,
+  key: string,
+  reducer: ('state, 'action) => 'state,
+  render: ('state, 'action => unit) => ReasonReact.reactElement,
+  renderChild: ('state, 'action => unit) => option(opaqueScreen),
+  popChild: 'state => 'state,
+  handedOffState: handedOffState('state, 'action)
+}
+and opaqueScreen =
+  | Screen(screenSpec('state, 'action)): opaqueScreen;
+
+type opaqueInstance;
+
+type state;
+
+type unknownState;
+
+type unknownAction;
+
+let makeScreen: unit => screenSpec(unknownState, unknownAction);
+
+let make:
+  (~initialScreen: screenSpec('a, 'b), unit) =>
+  ReasonReact.componentSpec(
+    opaqueInstance,
+    opaqueInstance,
+    ReasonReact.noRetainedProps,
+    ReasonReact.noRetainedProps,
+    opaqueInstance
+  );


### PR DESCRIPTION
Fixes #34 

This PR introduces a component API.

State:  It's not finished and I've temporarily removed few things (most notably screen.) It doesn't compile but it's a minor bug which it doesn't impact the API.

Details: This PR introduces a component API. Most notable features:

- Thanks to the component architecture you're able to naturally pass information down the "navigation" tree and up using props as you're used to from react. 
- It also removes the imperative calls to `push`/`pop` and replaces them with a declarative, state based API.
- It lets you statically express the navigation hierarchy. Any circular dependency in a view hierarchy needs to be explicit. I think it's great when it comes to understanding the codebase.
- You get rid of the functor which makes for a simpler api.
- Adding a JS API to this is very simple.

Example doesn't really make it shine because there's no state passed up/down the navigation tree.

I'm willing to finish this PR if this change is welcome. I realise it's a complete makeover but I believe it's a fundamentally better API.

Check out `StackNavigator.rei` and the example to get a feel of the change.