### PR TITLE
WIP support for Rebolt

### DIFF
--- a/bsconfig.json
+++ b/bsconfig.json
@@ -2,7 +2,7 @@
   "name": "reroute-native",
   "bsc-flags": ["-bs-no-version-header", "-bs-super-errors"],
   "refmt": 3,
-  "bs-dependencies": ["reason-react", "bs-react-native"],
+  "bs-dependencies": ["reason-react", "rebolt"],
   "reason": {
     "react-jsx": 2
   },

--- a/docs/ApiStackNavigator.md
+++ b/docs/ApiStackNavigator.md
@@ -16,9 +16,9 @@ sidebar_label: Stack Navigator
 ### ScreenProps
 
 * `~navigation`: Navigation instance
-* `~style?`: `BsReactNative.Style`
+* `~style?`: `Rebolt.Style`
 * `~headerTitle?`: `string`
-* `~headerStyle?`: `BsReactNative.Style`
+* `~headerStyle?`: `Rebolt.Style`
 * `~headerLeft?`: [Header.props](api-stack-navigator.html#header) `=>` [returnsComponent](api-stack-navigator.html#returnscomponent)
 * `~headerCenter?`: [Header.props](api-stack-navigator.html#header) `=>` [returnsComponent](api-stack-navigator.html#returnscomponent)
 * `~headerRight?`: [Header.props](api-stack-navigator.html#header) `=>` [returnsComponent](api-stack-navigator.html#returnscomponent)
@@ -51,7 +51,7 @@ sidebar_label: Stack Navigator
 
 ### config
 
-* `style`: option(`BsReactNative.Style`)
+* `style`: option(`Rebolt.Style`)
 * `title`: option(`string`)
 * `center`: option([returnsComponent](api-stack-navigator.html#returnscomponent))
 * `left`: option([returnsComponent](api-stack-navigator.html#returnscomponent))

--- a/docs/ApiTabNavigator.md
+++ b/docs/ApiTabNavigator.md
@@ -28,8 +28,8 @@ sidebar_label: Tab Navigator
 ### Props
 
 * `~label`: `string`
-* `~icon?`: `BsReactNative.Image.imageSource`
-* `~style?`: `BsReactNative.Style.t`
+* `~icon?`: `Rebolt.Image.imageSource`
+* `~style?`: `Rebolt.Style.t`
 
 ## Types
 

--- a/docs/Persisted.md
+++ b/docs/Persisted.md
@@ -109,7 +109,7 @@ The last thing is to render StackNavigator with `initialState` and `onStateChang
 ```js
 open NavigationConfig;
 
-open BsReactNative;
+open Rebolt;
 
 module Main = {
   type state = {persistedState: option(StackNavigator.persistedState)};

--- a/docs/TabNavigator.md
+++ b/docs/TabNavigator.md
@@ -56,7 +56,7 @@ open NavigationConfig;
 
 open TabNavigator;
 
-open BsReactNative;
+open Rebolt;
 
 module Styles = {
   open Style;

--- a/example/.native/ios/ReasonDemo.xcodeproj/project.pbxproj
+++ b/example/.native/ios/ReasonDemo.xcodeproj/project.pbxproj
@@ -36,6 +36,7 @@
 		2DCD954D1E0B4F2C00145EB5 /* ReasonDemoTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 00E356F21AD99517003FC87E /* ReasonDemoTests.m */; };
 		5E9157361DD0AC6A00FF2AA8 /* libRCTAnimation.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 5E9157331DD0AC6500FF2AA8 /* libRCTAnimation.a */; };
 		832341BD1AAA6AB300B99B32 /* libRCTText.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 832341B51AAA6A8300B99B32 /* libRCTText.a */; };
+		AD07885A2080C11D00FED55A /* RCTMediaPlayerManager.m in Sources */ = {isa = PBXBuildFile; fileRef = AD0788592080C11D00FED55A /* RCTMediaPlayerManager.m */; };
 		AD4AF708206BC4BA00269C07 /* libRNGestureHandler.a in Frameworks */ = {isa = PBXBuildFile; fileRef = AD4AF707206BC4AB00269C07 /* libRNGestureHandler.a */; };
 		ADBDB9381DFEBF1600ED6528 /* libRCTBlob.a in Frameworks */ = {isa = PBXBuildFile; fileRef = ADBDB9271DFEBF0700ED6528 /* libRCTBlob.a */; };
 /* End PBXBuildFile section */
@@ -349,6 +350,8 @@
 		5E91572D1DD0AC6500FF2AA8 /* RCTAnimation.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTAnimation.xcodeproj; path = "../../../node_modules/react-native/Libraries/NativeAnimation/RCTAnimation.xcodeproj"; sourceTree = "<group>"; };
 		78C398B01ACF4ADC00677621 /* RCTLinking.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTLinking.xcodeproj; path = "../../../node_modules/react-native/Libraries/LinkingIOS/RCTLinking.xcodeproj"; sourceTree = "<group>"; };
 		832341B01AAA6A8300B99B32 /* RCTText.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTText.xcodeproj; path = "../../../node_modules/react-native/Libraries/Text/RCTText.xcodeproj"; sourceTree = "<group>"; };
+		AD0788582080C11D00FED55A /* RCTMediaPlayerManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = RCTMediaPlayerManager.h; path = ReasonDemo/RCTMediaPlayerManager.h; sourceTree = "<group>"; };
+		AD0788592080C11D00FED55A /* RCTMediaPlayerManager.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = RCTMediaPlayerManager.m; path = ReasonDemo/RCTMediaPlayerManager.m; sourceTree = "<group>"; };
 		AD4AF6CD206BC4AB00269C07 /* RNGestureHandler.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RNGestureHandler.xcodeproj; path = "../../../node_modules/react-native-gesture-handler/ios/RNGestureHandler.xcodeproj"; sourceTree = "<group>"; };
 		ADBDB91F1DFEBF0600ED6528 /* RCTBlob.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTBlob.xcodeproj; path = "../../../node_modules/react-native/Libraries/Blob/RCTBlob.xcodeproj"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -497,6 +500,8 @@
 				13B07FB61A68108700A75B9A /* Info.plist */,
 				13B07FB11A68108700A75B9A /* LaunchScreen.xib */,
 				13B07FB71A68108700A75B9A /* main.m */,
+				AD0788582080C11D00FED55A /* RCTMediaPlayerManager.h */,
+				AD0788592080C11D00FED55A /* RCTMediaPlayerManager.m */,
 			);
 			name = ReasonDemo;
 			sourceTree = "<group>";
@@ -1143,6 +1148,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				13B07FBC1A68108700A75B9A /* AppDelegate.m in Sources */,
+				AD07885A2080C11D00FED55A /* RCTMediaPlayerManager.m in Sources */,
 				13B07FC11A68108700A75B9A /* main.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/example/.native/ios/ReasonDemo/RCTMediaPlayerManager.h
+++ b/example/.native/ios/ReasonDemo/RCTMediaPlayerManager.h
@@ -1,0 +1,14 @@
+//
+//  RCTMediaPlayerManager.h
+//  ReasonDemo
+//
+//  Created by Mike Grabowski on 13/04/2018.
+//  Copyright © 2018 Facebook. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import <React/RCTBridgeModule.h>
+
+@interface RCTMediaPlayerManager : NSObject<RCTBridgeModule>
+
+@end

--- a/example/.native/ios/ReasonDemo/RCTMediaPlayerManager.m
+++ b/example/.native/ios/ReasonDemo/RCTMediaPlayerManager.m
@@ -1,0 +1,24 @@
+//
+//  RCTMediaPlayerManager.m
+//  ReasonDemo
+//
+//  Created by Mike Grabowski on 05/04/2018.
+//  Copyright © 2018 Facebook. All rights reserved.
+//
+
+#import "RCTMediaPlayerManager.h"
+
+@implementation RCTMediaPlayerManager
+
+RCT_EXPORT_MODULE();
+
+- (void)play {}
+
+- (void)stop {}
+
+- (void)next:(NSString*)url {
+  
+}
+
+@end
+

--- a/example/About.re
+++ b/example/About.re
@@ -2,7 +2,7 @@ open NavigationConfig;
 
 open TabNavigator;
 
-open BsReactNative;
+open Rebolt;
 
 module Styles = {
   open Style;

--- a/example/Admin.re
+++ b/example/Admin.re
@@ -1,6 +1,6 @@
 open NavigationConfig;
 
-open BsReactNative;
+open Rebolt;
 
 let component = ReasonReact.statelessComponent("Admin");
 

--- a/example/App.re
+++ b/example/App.re
@@ -1,6 +1,6 @@
 open NavigationConfig;
 
-open BsReactNative;
+open Rebolt;
 
 module Main = {
   let component = ReasonReact.statelessComponent("Main");

--- a/example/ContactList.re
+++ b/example/ContactList.re
@@ -2,7 +2,7 @@ open NavigationConfig;
 
 open TabNavigator;
 
-open BsReactNative;
+open Rebolt;
 
 let component = ReasonReact.statelessComponent("Contacts");
 

--- a/example/CustomHome.re
+++ b/example/CustomHome.re
@@ -1,4 +1,4 @@
-open BsReactNative;
+open Rebolt;
 
 open NavigationConfig;
 

--- a/example/CustomMessages.re
+++ b/example/CustomMessages.re
@@ -1,4 +1,4 @@
-open BsReactNative;
+open Rebolt;
 
 open NavigationConfig;
 

--- a/example/CustomProfile.re
+++ b/example/CustomProfile.re
@@ -1,4 +1,4 @@
-open BsReactNative;
+open Rebolt;
 
 open NavigationConfig;
 

--- a/example/CustomProfileDetails.re
+++ b/example/CustomProfileDetails.re
@@ -1,4 +1,4 @@
-open BsReactNative;
+open Rebolt;
 
 open NavigationConfig;
 

--- a/example/CustomProfileStats.re
+++ b/example/CustomProfileStats.re
@@ -1,4 +1,4 @@
-open BsReactNative;
+open Rebolt;
 
 open NavigationConfig;
 

--- a/example/CustomTabBar.re
+++ b/example/CustomTabBar.re
@@ -1,4 +1,4 @@
-open BsReactNative;
+open Rebolt;
 
 open NavigationConfig;
 

--- a/example/CustomTabBarExample.re
+++ b/example/CustomTabBarExample.re
@@ -1,4 +1,4 @@
-open BsReactNative;
+open Rebolt;
 
 open NavigationConfig;
 

--- a/example/Home.re
+++ b/example/Home.re
@@ -1,6 +1,6 @@
 open NavigationConfig;
 
-open BsReactNative;
+open Rebolt;
 
 let component = ReasonReact.statelessComponent("Home");
 

--- a/example/Likes.re
+++ b/example/Likes.re
@@ -2,7 +2,7 @@ open NavigationConfig;
 
 open TabNavigator;
 
-open BsReactNative;
+open Rebolt;
 
 module Styles = {
   open Style;

--- a/example/Messages.re
+++ b/example/Messages.re
@@ -2,7 +2,7 @@ open NavigationConfig;
 
 open TabNavigator;
 
-open BsReactNative;
+open Rebolt;
 
 let component = ReasonReact.statelessComponent("Messages");
 

--- a/example/Settings.re
+++ b/example/Settings.re
@@ -2,7 +2,7 @@ open NavigationConfig;
 
 open TabNavigator;
 
-open BsReactNative;
+open Rebolt;
 
 let component = ReasonReact.statelessComponent("Settings");
 

--- a/example/TabExample.re
+++ b/example/TabExample.re
@@ -1,4 +1,4 @@
-open BsReactNative;
+open Rebolt;
 
 open NavigationConfig;
 

--- a/example/UserProfile.re
+++ b/example/UserProfile.re
@@ -1,6 +1,6 @@
 open NavigationConfig;
 
-open BsReactNative;
+open Rebolt;
 
 let screenWidth = Dimensions.get(`screen)##width;
 

--- a/example/Welcome.re
+++ b/example/Welcome.re
@@ -1,6 +1,6 @@
 open NavigationConfig;
 
-open BsReactNative;
+open Rebolt;
 
 let screenWidth = Dimensions.get(`screen)##width;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,14 @@
+{
+  "name": "reroute-native",
+  "version": "0.0.5",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "rebolt": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/rebolt/-/rebolt-0.1.0.tgz",
+      "integrity": "sha512-8jf2ZRYS1N+Lzy8kTZaxsUvP+owGYwEwEYLbh/EmNinMhTyRIgKquBQywfm4qtyf+CxCNusRu1RHKwgY/Ff5tg==",
+      "dev": true
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -10,11 +10,15 @@
     "prepublish": "npm run build",
     "run-ios": "react-native run-ios --project-path \"./example/.native/ios\"",
     "run-android": "react-native run-android --root \"./example/.native\"",
-    "start-example":
-      "node ./node_modules/react-native/local-cli/cli.js start --root ./example",
+    "start-example": "node ./node_modules/react-native/local-cli/cli.js start --root ./example",
     "test": "exit 0"
   },
-  "keywords": ["router", "react", "reason", "reasonml"],
+  "keywords": [
+    "router",
+    "react",
+    "reason",
+    "reasonml"
+  ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/callstack/reroute-native.git"
@@ -26,15 +30,15 @@
   },
   "homepage": "https://github.com/callstack/reroute-native#readme",
   "devDependencies": {
-    "bs-platform": "^3.0.0",
-    "bs-react-native": "^0.8.0",
+    "bs-platform": "^3.1.5",
     "react": "^16.3.0-alpha.1",
     "react-native": "0.54.0",
     "react-native-gesture-handler": "^1.0.0-alpha.41",
-    "reason-react": "^0.4.1"
+    "reason-react": "^0.4.1",
+    "rebolt": "^0.1.0"
   },
   "peerDependencies": {
-    "bs-react-native": "^0.8.0",
+    "rebolt": "^0.1.0",
     "react-native-gesture-handler": "*",
     "reason-react": "*"
   }

--- a/src/Animation.re
+++ b/src/Animation.re
@@ -1,4 +1,4 @@
-open BsReactNative;
+open Rebolt;
 
 type interpolator = Animated.Value.t => Style.t;
 

--- a/src/Animation.rei
+++ b/src/Animation.rei
@@ -1,7 +1,7 @@
 /**
  * Interpolates style
  */
-type interpolator = BsReactNative.Animated.Value.t => BsReactNative.Style.t;
+type interpolator = Rebolt.Animated.Value.t => Rebolt.Style.t;
 
 /**
  * Animation type
@@ -15,13 +15,13 @@ type interpolator = BsReactNative.Animated.Value.t => BsReactNative.Style.t;
 type t = {
   func:
     (
-      ~value: BsReactNative.Animated.Value.value,
+      ~value: Rebolt.Animated.Value.value,
       ~toValue: [
-                  | `animated(BsReactNative.Animated.Value.value)
+                  | `animated(Rebolt.Animated.Value.value)
                   | `raw(float)
                 ]
     ) =>
-    BsReactNative.Animated.CompositeAnimation.t,
+    Rebolt.Animated.CompositeAnimation.t,
   forCard: interpolator,
   forHeader: interpolator,
 };

--- a/src/Header.re
+++ b/src/Header.re
@@ -1,9 +1,9 @@
-open BsReactNative;
+open Rebolt;
 
 open Utils;
 
 type config = {
-  style: option(BsReactNative.Style.t),
+  style: option(Rebolt.Style.t),
   title: option(string),
   center: option(returnsComponent),
   left: option(returnsComponent),

--- a/src/Header.rei
+++ b/src/Header.rei
@@ -1,6 +1,6 @@
 /** Header configuration object */
 type config = {
-  style: option(BsReactNative.Style.t),
+  style: option(Rebolt.Style.t),
   title: option(string),
   center: option(returnsComponent),
   left: option(returnsComponent),
@@ -17,7 +17,7 @@ and screen = {
 and props = {
   screens: array(screen),
   activeScreen: int,
-  animatedValue: BsReactNative.Animated.Value.t,
+  animatedValue: Rebolt.Animated.Value.t,
   pop: string => unit,
 };
 

--- a/src/HeaderInterpolator.re
+++ b/src/HeaderInterpolator.re
@@ -1,4 +1,4 @@
-open BsReactNative;
+open Rebolt;
 
 type interpolator = Animated.Value.t => Style.t;
 

--- a/src/HeaderInterpolator.rei
+++ b/src/HeaderInterpolator.rei
@@ -1,4 +1,4 @@
-type interpolator = BsReactNative.Animated.Value.t => BsReactNative.Style.t;
+type interpolator = Rebolt.Animated.Value.t => Rebolt.Style.t;
 
 type t = {
   forHeaderCenter: interpolator,

--- a/src/StackNavigator.re
+++ b/src/StackNavigator.re
@@ -1,4 +1,4 @@
-open BsReactNative;
+open Rebolt;
 
 open Utils;
 

--- a/src/StackNavigator.rei
+++ b/src/StackNavigator.rei
@@ -43,9 +43,9 @@ module CreateStackNavigator:
         let make:
           (
             ~navigation: navigation,
-            ~style: BsReactNative.Style.t=?,
+            ~style: Rebolt.Style.t=?,
             ~headerTitle: string=?,
-            ~headerStyle: BsReactNative.Style.t=?,
+            ~headerStyle: Rebolt.Style.t=?,
             ~headerLeft: Header.returnsComponent=?,
             ~headerCenter: Header.returnsComponent=?,
             ~headerRight: Header.returnsComponent=?,

--- a/src/TabNavigator.re
+++ b/src/TabNavigator.re
@@ -1,4 +1,4 @@
-open BsReactNative;
+open Rebolt;
 
 module Styles = {
   open Style;

--- a/src/TabNavigator.rei
+++ b/src/TabNavigator.rei
@@ -70,8 +70,8 @@ module CreateTabNavigator:
           let make:
             (
               ~label: string,
-              ~icon: BsReactNative.Image.imageSource=?,
-              ~style: BsReactNative.Style.t=?,
+              ~icon: Rebolt.Image.imageSource=?,
+              ~style: Rebolt.Style.t=?,
               'a
             ) =>
             ReasonReact.componentSpec(

--- a/src/private/AnimatedUtils.re
+++ b/src/private/AnimatedUtils.re
@@ -1,4 +1,4 @@
-open BsReactNative.Animated;
+open Rebolt.Animated;
 
 
 /***

--- a/yarn.lock
+++ b/yarn.lock
@@ -1266,13 +1266,9 @@ braces@^2.3.1:
     split-string "^3.0.2"
     to-regex "^3.0.1"
 
-bs-platform@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.npmjs.org/bs-platform/-/bs-platform-3.0.0.tgz#38f200730db52fdea37819376b6ac3dfb20244c0"
-
-bs-react-native@^0.8.0:
-  version "0.8.0"
-  resolved "https://registry.yarnpkg.com/bs-react-native/-/bs-react-native-0.8.0.tgz#1e68b75ed78aad858548456fd985632b8642acfe"
+bs-platform@^3.1.5:
+  version "3.1.5"
+  resolved "https://registry.yarnpkg.com/bs-platform/-/bs-platform-3.1.5.tgz#fb34ee4702bc9163848d5537096c4f31ebaeed40"
 
 bser@^2.0.0:
   version "2.0.0"
@@ -3554,6 +3550,10 @@ reason-react@^0.4.1:
   dependencies:
     react ">=15.0.0 || >=16.0.0"
     react-dom ">=15.0.0 || >=16.0.0"
+
+rebolt@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/rebolt/-/rebolt-0.1.0.tgz#002fd14ccce22feccd57eb7ea995372662898f71"
 
 regenerate@^1.2.1:
   version "1.3.3"


### PR DESCRIPTION
Uses Rebolt instead of `bs-react-native`. This is just the first step of series of pull request to adopt fully to `rebolt-navigation`.