### PR TITLE
Update easing function of Android animation

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "react-native": "^0.55.4",
     "react-native-gesture-handler": "^1.0.0-alpha.41",
     "reason-react": "^0.4.1",
-    "rebolt": "callstackincubator/rebolt#1374ada"
+    "rebolt": "callstackincubator/rebolt#65ebba2"
   },
   "peerDependencies": {
     "react-native-gesture-handler": "*",

--- a/src/Animation.re
+++ b/src/Animation.re
@@ -55,11 +55,13 @@ let slideHorizontal = {
 
 let fadeVertical = {
   func:
-    Animated.Timing.animate(
-      ~duration=350.0,
-      ~easing=t => Js.Math.pow_float(~base=t, ~exp=5.0),
-      ~useNativeDriver=true,
-      (),
+    Animated.(
+      Timing.animate(
+        ~duration=350.0,
+        ~easing=Easing.out(Easing.poly(5.0)),
+        ~useNativeDriver=true,
+        (),
+      )
     ),
   forCard: value =>
     Style.(

--- a/yarn.lock
+++ b/yarn.lock
@@ -3640,9 +3640,9 @@ rebolt@callstackincubator/rebolt#1374ada:
   version "0.1.0"
   resolved "https://codeload.github.com/callstackincubator/rebolt/tar.gz/1374ada18b4b6bfc822168a92ce8d3715f080cbf"
 
-rebolt@callstackincubator/rebolt#2392966:
+rebolt@callstackincubator/rebolt#65ebba2:
   version "0.1.0"
-  resolved "https://codeload.github.com/callstackincubator/rebolt/tar.gz/239296654f98854fd82c4f120892ef3147ef2f9d"
+  resolved "https://codeload.github.com/callstackincubator/rebolt/tar.gz/65ebba2a74382d40e43806382061c2fce9dadf82"
 
 regenerate@^1.2.1:
   version "1.3.3"


### PR DESCRIPTION
Previously it wasn't possible to use `Easing.poly` due to incorrect typing in `bs-react-native`.  This has been fixed in `rebolt` and the following pull request represents set of changes that were performed as a result.