### PR TITLE
[Bug Fix] Header Style on IOS

### DIFF
--- a/src/Header.re
+++ b/src/Header.re
@@ -365,9 +365,16 @@ module IOSImpl = {
           )
         </Animated.View>;
       let lastIdx = Array.length(screens) - 1;
-      <SafeAreaView style=Styles.container>
+      <SafeAreaView
+        style=Style.(
+                concat([
+                  Styles.container,
+                  scr(props).header.style
+                  |> Js.Option.getWithDefault(style([])),
+                ])
+              )>
         <View style=Styles.header>
-          Js.Option.(
+          (
             screens
             |> Array.mapi((idx: int, screen) => {
                  /**


### PR DESCRIPTION
I try to tackle the issue on #116 . I think it's because the headerStyle props never get passed to `SafeAreaView`.
So, here's the result after I define the style on `Home`.
```ocaml
    <StackNavigator.Screen
      headerTitle="Homes"
      navigation=nav
      headerStyle=Style.(style([backgroundColor(String("red"))]))>
      ...(
           () =>
             <View style=Styles.continer>
               <Text style=Styles.title>
                 (ReasonReact.string("Home screen"))
               </Text>
               (renderButtons(nav))
             </View>
         )
    </StackNavigator.Screen>,
```
![simulator screen shot - iphone 6 - 2018-07-23 at 00 43 41](https://user-images.githubusercontent.com/7804066/43048459-f46a594a-8e11-11e8-94c2-1a4e88b0fb2e.png)
