### PR TITLE
Fix react-native version

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "devDependencies": {
     "bs-platform": "^4.0.0",
     "react": "^16.3.0-alpha.1",
-    "react-native": "^0.55.4",
+    "react-native": "~0.55.4",
     "react-native-gesture-handler": "^1.0.0-alpha.41",
     "reason-react": "^0.4.1",
     "rebolt": "^0.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3502,7 +3502,7 @@ react-native-gesture-handler@^1.0.0-alpha.41:
     invariant "^2.2.2"
     prop-types "^15.5.10"
 
-react-native@^0.55.4:
+react-native@~0.55.4:
   version "0.55.4"
   resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.55.4.tgz#eecffada3750a928e2ddd07cf11d857ae9751c30"
   dependencies:


### PR DESCRIPTION
We were using `^` (caret ranges) which was downloading `react-native` versions above 0.55. That was causing fresh clone to have broken example app.